### PR TITLE
Remove readline/promises module 

### DIFF
--- a/src/eventLoopActions/getRoomAction.js
+++ b/src/eventLoopActions/getRoomAction.js
@@ -1,5 +1,8 @@
 const rl = require('../utils/readLine');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const getRoomType = async () => {
   console.log(
@@ -26,7 +29,7 @@ const getRoomType = async () => {
     chalk.cyan('Create a private room'),
     chalk.red('---\n')
   );
-  let choice = await rl.question('');
+  let choice = await question('');
 
   return choice;
 };

--- a/src/eventLoopActions/getRoomAction.js
+++ b/src/eventLoopActions/getRoomAction.js
@@ -1,8 +1,5 @@
-const rl = require('../utils/readLine');
+const { question } = require('../utils/readLine.js');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const getRoomType = async () => {
   console.log(

--- a/src/eventLoopActions/loginRegisterActions/getUserAction.js
+++ b/src/eventLoopActions/loginRegisterActions/getUserAction.js
@@ -1,5 +1,8 @@
 const rl = require('../../utils/readLine');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const getUserAction = async () => {
   console.log(
@@ -20,7 +23,7 @@ const getUserAction = async () => {
     chalk.cyan('Register'),
     chalk.red('---\n')
   );
-  let choice = await rl.question('');
+  let choice = await question('');
 
   return choice;
 };

--- a/src/eventLoopActions/loginRegisterActions/getUserAction.js
+++ b/src/eventLoopActions/loginRegisterActions/getUserAction.js
@@ -1,8 +1,5 @@
-const rl = require('../../utils/readLine');
+const { question } = require('../../utils/readLine.js');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const getUserAction = async () => {
   console.log(

--- a/src/eventLoopActions/loginRegisterActions/login.js
+++ b/src/eventLoopActions/loginRegisterActions/login.js
@@ -1,14 +1,17 @@
 const rl = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const login = async (socket) => {
   let user = null;
   do {
     console.log(chalk.cyan('\nPlease enter your username:'));
-    let username = await rl.question('');
+    let username = await question('');
     console.log(chalk.cyan('Please enter your password'));
-    let password = await rl.question('');
+    let password = await question('');
 
     try {
       let res = await axios.post(

--- a/src/eventLoopActions/loginRegisterActions/login.js
+++ b/src/eventLoopActions/loginRegisterActions/login.js
@@ -1,9 +1,6 @@
-const rl = require('../../utils/readLine.js');
+const { question } = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const login = async (socket) => {
   let user = null;

--- a/src/eventLoopActions/loginRegisterActions/register.js
+++ b/src/eventLoopActions/loginRegisterActions/register.js
@@ -1,9 +1,6 @@
-const rl = require('../../utils/readLine.js');
+const { question } = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const register = async (socket) => {
   let user = null;

--- a/src/eventLoopActions/loginRegisterActions/register.js
+++ b/src/eventLoopActions/loginRegisterActions/register.js
@@ -1,14 +1,17 @@
 const rl = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const register = async (socket) => {
   let user = null;
   do {
     console.log(chalk.cyan('\nPlease enter a username:'));
-    let username = await rl.question('');
+    let username = await question('');
     console.log(chalk.cyan('Please enter a password'));
-    let password = await rl.question('');
+    let password = await question('');
 
     let body = { username, password };
 

--- a/src/eventLoopActions/messageLoop.js
+++ b/src/eventLoopActions/messageLoop.js
@@ -1,4 +1,4 @@
-const rl = require('../utils/readLine');
+const { rl } = require('../utils/readLine.js');
 const rooms = require('../data/publicRooms.json');
 const commandList = require('../socket/commands.json');
 const chalk = require('chalk');

--- a/src/eventLoopActions/privateRoomActions/choosePrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/choosePrivateRoom.js
@@ -2,6 +2,9 @@ const fetchPrivateRooms = require('./fetchPrivateRooms');
 const rl = require('../../utils/readLine');
 const chalk = require('chalk');
 const joinPrivateRoom = require('./joinPrivateRoom');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const choosePrivateRoom = async () => {
   let roomData = await fetchPrivateRooms();
@@ -36,7 +39,7 @@ const choosePrivateRoom = async () => {
     );
   }
 
-  let answer = parseInt(await rl.question(''));
+  let answer = parseInt(await question(''));
 
   while (answer < 1 || answer > rooms.length || Number.isNaN(answer)) {
     idx = 1;
@@ -49,7 +52,7 @@ const choosePrivateRoom = async () => {
         chalk.red('---\n')
       );
     }
-    answer = parseInt(await rl.question(''));
+    answer = parseInt(await question(''));
   }
   let roomResult = await joinPrivateRoom(rooms[answer - 1].roomname);
   return roomResult;

--- a/src/eventLoopActions/privateRoomActions/choosePrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/choosePrivateRoom.js
@@ -1,10 +1,7 @@
 const fetchPrivateRooms = require('./fetchPrivateRooms');
-const rl = require('../../utils/readLine');
+const { question } = require('../../utils/readLine.js');
 const chalk = require('chalk');
 const joinPrivateRoom = require('./joinPrivateRoom');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const choosePrivateRoom = async () => {
   let roomData = await fetchPrivateRooms();

--- a/src/eventLoopActions/privateRoomActions/createPrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/createPrivateRoom.js
@@ -1,10 +1,6 @@
-const rl = require('../../utils/readLine.js');
+const { question } = require('../../utils/readLine');
 const axios = require('axios');
 const chalk = require('chalk');
-
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const createPrivateRoom = async () => {
   let roomname = null;

--- a/src/eventLoopActions/privateRoomActions/createPrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/createPrivateRoom.js
@@ -2,14 +2,18 @@ const rl = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
 
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
+
 const createPrivateRoom = async () => {
   let roomname = null;
 
   do {
     console.log(chalk.cyan('\nPlease enter a name for your room:'));
-    roomname = await rl.question('');
+    roomname = await question('');
     console.log(chalk.cyan('Please enter a password for your room'));
-    let password = await rl.question('');
+    let password = await question('');
 
     let body = { roomname, password };
 

--- a/src/eventLoopActions/privateRoomActions/joinPrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/joinPrivateRoom.js
@@ -1,9 +1,6 @@
-const rl = require('../../utils/readLine.js');
+const { question } = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 const joinPrivateRoom = async (roomname) => {
   let room = null;

--- a/src/eventLoopActions/privateRoomActions/joinPrivateRoom.js
+++ b/src/eventLoopActions/privateRoomActions/joinPrivateRoom.js
@@ -1,12 +1,15 @@
 const rl = require('../../utils/readLine.js');
 const axios = require('axios');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 const joinPrivateRoom = async (roomname) => {
   let room = null;
   do {
     console.log(chalk.cyan('Please the password for this room'));
-    let password = await rl.question('');
+    let password = await question('');
     try {
       let res = await axios.post(
         `${process.env.SOCKET_SERVER}joinroom`,

--- a/src/eventLoopActions/roomChoice.js
+++ b/src/eventLoopActions/roomChoice.js
@@ -1,9 +1,6 @@
-const rl = require('../utils/readLine');
+const { question } = require('../utils/readLine.js');
 const rooms = require('../data/publicRooms.json');
 const chalk = require('chalk');
-const util = require('util');
-
-const question = util.promisify(rl.question).bind(rl);
 
 module.exports = async function () {
   console.log(

--- a/src/eventLoopActions/roomChoice.js
+++ b/src/eventLoopActions/roomChoice.js
@@ -1,6 +1,9 @@
 const rl = require('../utils/readLine');
 const rooms = require('../data/publicRooms.json');
 const chalk = require('chalk');
+const util = require('util');
+
+const question = util.promisify(rl.question).bind(rl);
 
 module.exports = async function () {
   console.log(
@@ -19,13 +22,13 @@ module.exports = async function () {
     );
   }
 
-  let answer = await rl.question('');
+  let answer = await question('');
 
   // eslint-disable-next-line no-prototype-builtins
   while (!rooms.hasOwnProperty(answer)) {
     console.log(chalk.bgRed('\n Invalid room choice \n'));
 
-    answer = await rl.question(``);
+    answer = await question(``);
   }
 
   return rooms[answer];

--- a/src/utils/readLine.js
+++ b/src/utils/readLine.js
@@ -1,4 +1,7 @@
 const readline = require('readline');
 const rl = readline.createInterface(process.stdin, process.stdout);
+const util = require('util');
 
-module.exports = rl;
+const question = util.promisify(rl.question).bind(rl);
+
+module.exports = { rl, question };

--- a/src/utils/readLine.js
+++ b/src/utils/readLine.js
@@ -1,5 +1,4 @@
-//const readline = require('readline');
-const readlinePromises = require('readline/promises');
-const rl = readlinePromises.createInterface(process.stdin, process.stdout);
+const readline = require('readline');
+const rl = readline.createInterface(process.stdin, process.stdout);
 
 module.exports = rl;


### PR DESCRIPTION
This PR removes the `readline/promises` module so we are no longer dependent on node version 17.1.0.
I was unable to package the application as an executable when our code was dependent on node version 17.1.0, should go a lot smoother using v16.

We are still able to use async/await in the code due to bringing in the Node `Util` module and using the builtin `util.promisify` method around the `rl.question` call. The app still seems to work as it did before, would like to test it with everyone tomorrow morning before merging.